### PR TITLE
add nuget.projectmodel packagereference

### DIFF
--- a/src/SmartCodeGenerator.Engine/SmartCodeGenerator.Engine.csproj
+++ b/src/SmartCodeGenerator.Engine/SmartCodeGenerator.Engine.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NuGet.ProjectModel" Version="5.5.1" />
     <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
fixes #3 and https://github.com/cezarypiatek/MappingGenerator/issues/110

probably also fixes other issues around project references, but I have not tested those.